### PR TITLE
Allow container to restart always

### DIFF
--- a/fcosmine/root/home/fcosmine/compconf/fcosmine.yml
+++ b/fcosmine/root/home/fcosmine/compconf/fcosmine.yml
@@ -46,4 +46,4 @@ services:
       - "9999:25565/tcp"
     volumes:
       - "/home/fcosmine/fosdemcd/data:/data:Z"
-    restart: "unless-stopped"
+    restart: "always"


### PR DESCRIPTION
It happens to stop (and never start again) after the first boot.

Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>