### PR TITLE
Remove service persistence after installation

### DIFF
--- a/fcosmine/root/etc/systemd/system/install-podman-compose-and-firewalld.service
+++ b/fcosmine/root/etc/systemd/system/install-podman-compose-and-firewalld.service
@@ -8,7 +8,6 @@ SuccessAction=reboot
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/rpm-ostree install --assumeyes --allow-inactive podman-compose firewalld
 
 [Install]


### PR DESCRIPTION
This helps to finally execute the specified `SuccessAction` after the installation is completed.

Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>