### PR TITLE
Change condition check for server start

### DIFF
--- a/fcosmine/root/etc/systemd/system/start-minecraft-dedicated-server.service
+++ b/fcosmine/root/etc/systemd/system/start-minecraft-dedicated-server.service
@@ -2,11 +2,10 @@
 Description=Start Minecraft dedicated server
 After=network-online.target podman.service
 Requires=network-online.target podman.service
-ConditionPathExists=/var/lib/done-install-podman-compose-and-firewalld.stamp
+ConditionPathExists=/usr/bin/podman-compose
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/podman-compose -f /home/fcosmine/compconf/fcosmine.yml up -d
 
 [Install]


### PR DESCRIPTION
Check the presence of the executable binary instead of the stamp file.

Remove the `RemainAfterStart` directive from the `Service` section.

Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>