### PR TITLE
Remove the restart directive from the compose config

### DIFF
--- a/fcosmine/root/home/fcosmine/compconf/fcosmine.yml
+++ b/fcosmine/root/home/fcosmine/compconf/fcosmine.yml
@@ -46,4 +46,3 @@ services:
       - "9999:25565/tcp"
     volumes:
       - "/home/fcosmine/fosdemcd/data:/data:Z"
-    restart: "always"


### PR DESCRIPTION
No need for that directive in the compose configuration when the systemd unit `start-minecraft-dedicated-server.service` is enabled to start across multiple reboots.

Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>