### PR TITLE
Remove the detached status and oneshot nature

### DIFF
--- a/fcosmine/root/etc/systemd/system/start-minecraft-dedicated-server.service
+++ b/fcosmine/root/etc/systemd/system/start-minecraft-dedicated-server.service
@@ -5,8 +5,7 @@ Requires=network-online.target podman.service
 ConditionPathExists=/usr/bin/podman-compose
 
 [Service]
-Type=oneshot
-ExecStart=/usr/bin/podman-compose -f /home/fcosmine/compconf/fcosmine.yml up -d
+ExecStart=/usr/bin/podman-compose -f /home/fcosmine/compconf/fcosmine.yml up
 ExecStop=/usr/bin/podman-compose -f /home/fcosmine/compconf/fcosmine.yml down
 
 [Install]


### PR DESCRIPTION
Just because the service runs on every boot, it ain't `oneshot` no more and removing the detached status to keep the service running + not exiting out right after the container is set up.

Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>